### PR TITLE
Swordsmachine second phase speedup feature no longer works on level 0-3

### DIFF
--- a/Ultrapain/Patches/SwordsMachine.cs
+++ b/Ultrapain/Patches/SwordsMachine.cs
@@ -69,7 +69,7 @@ namespace Ultrapain.Patches
         {
             if (!__0)
             {
-                if (ConfigManager.swordsMachineSecondPhaseMode.value != ConfigManager.SwordsMachineSecondPhase.SpeedUp)
+                if (ConfigManager.swordsMachineSecondPhaseMode.value != ConfigManager.SwordsMachineSecondPhase.SpeedUp || __instance.secondPhasePosTarget != null)
                     return;
 
                 SwordsMachineFlag flag = __instance.GetComponent<SwordsMachineFlag>();
@@ -99,7 +99,7 @@ namespace Ultrapain.Patches
 
         static void Postfix(SwordsMachine __instance, Animator ___anim, EnemyIdentifier ___eid)
         {
-            if (ConfigManager.swordsMachineSecondPhaseMode.value != ConfigManager.SwordsMachineSecondPhase.SpeedUp)
+            if (ConfigManager.swordsMachineSecondPhaseMode.value != ConfigManager.SwordsMachineSecondPhase.SpeedUp || __instance.secondPhasePosTarget != null)
                 return;
 
             SwordsMachineFlag flag = __instance.GetComponent<SwordsMachineFlag>();
@@ -128,7 +128,7 @@ namespace Ultrapain.Patches
 
         static void Postfix(SwordsMachine __instance, Animator ___anim, EnemyIdentifier ___eid)
         {
-            if (ConfigManager.swordsMachineSecondPhaseMode.value != ConfigManager.SwordsMachineSecondPhase.SpeedUp)
+            if (ConfigManager.swordsMachineSecondPhaseMode.value != ConfigManager.SwordsMachineSecondPhase.SpeedUp || __instance.secondPhasePosTarget != null)
                 return;
 
             SwordsMachineFlag flag = __instance.GetComponent<SwordsMachineFlag>();
@@ -146,7 +146,7 @@ namespace Ultrapain.Patches
         }
     }
 
-    class SwordsMachine_SetSpeed_Patch
+    /*class SwordsMachine_SetSpeed_Patch
     {
         static bool Prefix(SwordsMachine __instance, ref Animator ___anim)
         {
@@ -159,7 +159,7 @@ namespace Ultrapain.Patches
 
             return false;
         }
-    }
+    }*/
 
     /*[HarmonyPatch(typeof(SwordsMachine))]
     [HarmonyPatch("Down")]

--- a/Ultrapain/Plugin.cs
+++ b/Ultrapain/Plugin.cs
@@ -445,7 +445,7 @@ namespace Ultrapain
             {
                 harmonyTweaks.Patch(GetMethod<SwordsMachine>("Knockdown"), prefix: GetHarmonyMethod(GetMethod<SwordsMachine_Knockdown_Patch>("Prefix")), postfix: GetHarmonyMethod(GetMethod<SwordsMachine_Knockdown_Patch>("Postfix")));
                 harmonyTweaks.Patch(GetMethod<SwordsMachine>("Down"), postfix: GetHarmonyMethod(GetMethod<SwordsMachine_Down_Patch>("Postfix")), prefix: GetHarmonyMethod(GetMethod<SwordsMachine_Down_Patch>("Prefix")));
-                harmonyTweaks.Patch(GetMethod<SwordsMachine>("SetSpeed"), prefix: GetHarmonyMethod(GetMethod<SwordsMachine_SetSpeed_Patch>("Prefix")));
+                //harmonyTweaks.Patch(GetMethod<SwordsMachine>("SetSpeed"), prefix: GetHarmonyMethod(GetMethod<SwordsMachine_SetSpeed_Patch>("Prefix")));
                 harmonyTweaks.Patch(GetMethod<SwordsMachine>("EndFirstPhase"), postfix: GetHarmonyMethod(GetMethod<SwordsMachine_EndFirstPhase_Patch>("Postfix")), prefix: GetHarmonyMethod(GetMethod<SwordsMachine_EndFirstPhase_Patch>("Prefix")));
             }
             if (ConfigManager.swordsMachineExplosiveSwordToggle.value)


### PR DESCRIPTION
Fix for #1 
\
This bug occurs when config value for `swordsMachineSecondPhaseMode` is set to `SpeedUp`
To fix the issue, speedup is only allowed to be applied when swordsmachine's `secondPhasePosTarget` is set to `null`, which means swordsmachine is not the one in level 0-3
When `swordsMachineSecondPhaseMode` is set to `Skip`, the issue does not appear since a similar countermeasure was already done before.