### PR TITLE
Make Discord RPC ignore rich text tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Issues related to game crashes and unintended behaviours
+title: "[BUG] Bug name here"
+labels: bug
+assignees: eternalUnion
+
+---
+
+# Description
+What went wrong and what was expected
+
+# Reproduction
+Describe steps to reproduce the issue. If the way of reproducing the issue is unknown, you can include as much information as possible on when it happens or how often it happens
+* Step 1:
+* Step 2:
+* ...
+
+# Console logs
+Put any abnormal console log (warnings/error) here. [How to open the console](https://docs.bepinex.dev/articles/user_guide/troubleshooting.html)
+
+# Extras
+Anything else you may want to include

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Post any ideas about the mod and it may get implemented
+title: "[FEATURE] Your idea goes here"
+labels: feature request
+assignees: eternalUnion
+
+---
+
+# Feature
+Describe your idea in as much detail as possible. Include any configurable values and its interactions with in-game variables (such as radiance)
+
+# Usage
+In what scenario this feature would be useful, what interactions this feature would provide, how often this feature would impact the game etc.
+
+# Extras
+Anything else you want to include

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: Feature Request
 about: Post any ideas about the mod and it may get implemented
 title: "[FEATURE] Your idea goes here"
 labels: feature request
-assignees: eternalUnion
+assignees: eternalUnion, UntotenTheo
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,6 +7,8 @@ assignees: eternalUnion
 
 ---
 
+[Please do not close the request after a revision release is posted. Request will be closed by the developer when it is implemented to the base version or when it is flagged as not planned]
+
 # Feature
 Describe your idea in as much detail as possible. Include any configurable values and its interactions with in-game variables (such as radiance)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# ULTRAPAIN - Configurable Difficulty Mod
+ULTRAPAIN is a mod that adds several unique mechanics to the game in order to allow the player to fine tune their difficulty as well as adding some brand new shiny tech. You can make the game as lenient- or as difficult- as you so desire.
+## Enemy Tweaks
+Every enemy, fodder to miniboss, has at least one unique change that can be configured. For example, Filth now explode on contact with the player, and Soldiers fire more than one burst of projectiles, plus a core. Every enemy can be fine-tuned to a player's preference, whether that's making the game hell, or simply relaxing.
+## Player Tweaks
+There are also new techniques added, such as Grenade Parrying, Rocket Parrying, Freezeframe Rocket Grappling, and Orbital Strikes. Everything is highly configurable, from the style bonus text and style points granted for performing a move, to damage and explosion size values.
+## Installation 
+1. Download and install [BepInEx](https://www.youtube.com/watch?v=meNiXcbPh_s) following this tutorial.
+2. Download and install [PluginConfigurator](https://thunderstore.io/c/ultrakill/p/EternalsTeam/PluginConfigurator/) to the BepInEx/Plugins folder.
+3. Download and install ULTRAPAIN, extracting the folder to the BepInEx/Plugins folder.
+4. Launch the game, enter the options menu, and configure to your personal preference.
+## Credits
+ EternalUnion - Developer ([Github](https://github.com/eternalUnion)) ([Reddit](https://www.reddit.com/user/eternalUnity)) ([Discord](https://discord.com/users/588747299774267403))\
+Eden's Blessing - War Crime Coverups ([YouTube](https://www.youtube.com/@edenarch))\
+Theo - Beta Tester/Content Creator ([YouTube](https://www.youtube.com/channel/UCxWja36ERsSck_YiOAd1uGA)) ([Discord](https://discord.com/users/468985297401806849))\
+BlightedBush - Beta Tester ([YouTube](https://www.youtube.com/channel/UCFENMOjMJ8lhOz0WnpGzeuQ))

--- a/Ultrapain/Patches/DiscordController.cs
+++ b/Ultrapain/Patches/DiscordController.cs
@@ -1,5 +1,7 @@
 ﻿using Discord;
 using HarmonyLib;
+using System.Text.RegularExpressions;
+
 
 namespace Ultrapain.Patches
 {
@@ -8,7 +10,14 @@ namespace Ultrapain.Patches
         static bool Prefix(DiscordController __instance, ref Activity ___cachedActivity)
         {
             if (___cachedActivity.State != null && ___cachedActivity.State == "DIFFICULTY: UKMD")
-                ___cachedActivity.State = $"DIFFICULTY: {ConfigManager.pluginName.value}";
+            {
+                Regex rich = new Regex(@"<[^>]*>");
+                string text = $"DIFFICULTY: {ConfigManager.pluginName.value}";
+                if (rich.IsMatch(text))
+                {
+                    ___cachedActivity.State = rich.Replace(text, string.Empty);
+                }
+            }
             return true;
         }
     }

--- a/Ultrapain/Patches/DiscordController.cs
+++ b/Ultrapain/Patches/DiscordController.cs
@@ -17,6 +17,10 @@ namespace Ultrapain.Patches
                 {
                     ___cachedActivity.State = rich.Replace(text, string.Empty);
                 }
+                else
+                {
+                    ___cachedActivity.State = text;
+                }
             }
             return true;
         }

--- a/Ultrapain/Patches/SteamFriends.cs
+++ b/Ultrapain/Patches/SteamFriends.cs
@@ -1,5 +1,6 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Steamworks;
+using System.Text.RegularExpressions;
 
 namespace Ultrapain.Patches
 {
@@ -10,7 +11,17 @@ namespace Ultrapain.Patches
             if (__1.ToLower() != "ukmd")
                 return true;
 
-            __1 = ConfigManager.pluginName.value;
+            Regex rich = new Regex(@"<[^>]*>");
+            string text = ConfigManager.pluginName.value;
+            if (rich.IsMatch(text))
+            {
+                __1 = rich.Replace(text, string.Empty);
+            }
+            else
+            {
+                __1 = text;
+            }
+
             return true;
         }
     }

--- a/Ultrapain/Ultrapain.csproj
+++ b/Ultrapain/Ultrapain.csproj
@@ -7,12 +7,6 @@
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
-    <BaseOutputPath>D:\Games\ULTRAKILL-CG\ULTRAKILL\BepInEx\plugins\UltraPain</BaseOutputPath>
-
-	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-	<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-	<OutputPath>D:\Games\ULTRAKILL-CG\ULTRAKILL\BepInEx\plugins\UltraPain</OutputPath>
-	<ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
If you had any rich text tags in the difficulty's name field, Discord RPC would display them, which isn't ideal.
![ULTRAKILL_GG0oMPV3MD](https://github.com/eternalUnion/UltraPain/assets/84527984/d67635f9-aa9b-44f3-b2f8-77092681e969)
![Discord_1SrIkHLIYn](https://github.com/eternalUnion/UltraPain/assets/84527984/9acdefac-558f-45c3-94ef-29e432c1f918)
With this PR, it no longer does that.
![Discord_KU8d1q5mOJ](https://github.com/eternalUnion/UltraPain/assets/84527984/1ef08797-4ef4-49c8-b855-f569a8f878a6)
